### PR TITLE
Fix a bug that caused compilation errors

### DIFF
--- a/cpufp_x86.c
+++ b/cpufp_x86.c
@@ -330,8 +330,16 @@ int main(int argc, char *argv[])
 	}
 
 	// Determine if it is all numbers
-	if (strspn(argv[1], "0123456789") == strlen(argv[i]))
-		int num_threads = atoi(argv[1]);
+	int num_threads;
+	if (strspn(argv[1], "0123456789") == strlen(argv[1]))
+	{
+		num_threads = atoi(argv[1]);
+	}
+	else
+	{
+		fprintf(stderr, "Invalid num_threads.\n");
+		exit(0);
+	}
 	printf("Thread(s): %d\n", num_threads);
 
 #ifdef _AVX512F_


### PR DESCRIPTION
Test with GCC 9

(1) Variable "i" in "strlen(argv[i]))" is not defined. I think it is a mistake and fix "strlen(argv[**i**]))" as "strlen(argv[**1**]))";
(2) Variable “num_threads” ought to be defined outside the brackets. 