### PR TITLE
opt: fix compile and link error.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,11 @@
-g++ -O3 -c cpuid_x86.cpp
-g++ -O3 -o cpuid_gen cpuid_x86.o
+g++ -O3 -std=c++11 -c cpuid_x86.cpp
+g++ -O3 -std=c++11 -o cpuid_gen cpuid_x86.o
 ./cpuid_gen
 sh build_kernel.sh
 
-g++ -O3 -c table.cpp
-g++ -O3 -c smtl.cpp
-g++ -O3 -c cpubm_x86.cpp
-g++ -O3 -c cpufp_x86.cpp
+g++ -O3 -std=c++11 -c table.cpp
+g++ -O3 -std=c++11 -c smtl.cpp
+g++ -O3 -std=c++11 -c cpubm_x86.cpp
+g++ -O3 -std=c++11 -c cpufp_x86.cpp
 
 sh link.sh

--- a/cpuid_x86.cpp
+++ b/cpuid_x86.cpp
@@ -196,7 +196,7 @@ void gen_cpufp_include_cpp()
 void gen_link()
 {
     ofstream lf("link.sh");
-    lf << "g++ -O3 -o cpufp table.o smtl.o cpubm_x86.o cpufp_x86.o";
+    lf << "g++ -O3 -lpthread -o cpufp table.o smtl.o cpubm_x86.o cpufp_x86.o";
     if (cpuid_x86_support(_CPUID_X86_SSE_))
     {
         lf << " cpufp_kernel_x86_sse.o";


### PR DESCRIPTION
update build.sh, fix compile and link error.

erros message:
``
#error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the
``

``
smtl.o: In function `smtl_thread_func(void*)':
smtl.cpp:(.text+0x63): undefined reference to `pthread_setaffinity_np'
smtl.o: In function `smtl_init(smtl_t**, std::vector<int, std::allocator<int> >&)':
smtl.cpp:(.text+0x3b8): undefined reference to `pthread_create'
smtl.o: In function `smtl_fini(smtl_t*)':
smtl.cpp:(.text+0x577): undefined reference to `pthread_join'
collect2: error: ld returned 1 exit status
``