### PR TITLE
add link flag -lpthread

### DIFF
--- a/cpuid_x86.cpp
+++ b/cpuid_x86.cpp
@@ -196,7 +196,7 @@ void gen_cpufp_include_cpp()
 void gen_link()
 {
     ofstream lf("link.sh");
-    lf << "g++ -O3 -o cpufp table.o smtl.o cpubm_x86.o cpufp_x86.o";
+    lf << "g++ -O3 -o cpufp table.o smtl.o cpubm_x86.o cpufp_x86.o -lpthread";
     if (cpuid_x86_support(_CPUID_X86_SSE_))
     {
         lf << " cpufp_kernel_x86_sse.o";


### PR DESCRIPTION
fix link error, by adding a link flag  -lpthread in file cpufp/cpuid_x86.cpp

erros messages:
$ ./build.sh
/usr/bin/ld: smtl.o: in function `smtl_thread_func(void*)':
smtl.cpp:(.text+0x78): undefined reference to `pthread_setaffinity_np'
/usr/bin/ld: smtl.o: in function `smtl_init(smtl_t**, std::vector<int, std::allocator<int> >&)':
smtl.cpp:(.text+0x3ff): undefined reference to `pthread_create'
/usr/bin/ld: smtl.o: in function `smtl_fini(smtl_t*)':
smtl.cpp:(.text+0x639): undefined reference to `pthread_join'
collect2: error: ld returned 1 exit status
