### PR TITLE
add riscv64 Vector Extension and SpaceMiT Matrix Extension support

### DIFF
--- a/build_riscv64.sh
+++ b/build_riscv64.sh
@@ -1,0 +1,30 @@
+SRC=riscv64
+ASM=$SRC/asm
+COMM=common
+BUILD_DIR=build_dir
+
+# make directory
+if [ -d "$BUILD_DIR" ]; then
+    rm -rf $BUILD_DIR/*
+else
+    mkdir $BUILD_DIR
+fi
+
+# build common tools
+g++ -O3 -c $COMM/table.cpp -o $BUILD_DIR/table.o
+g++ -O3 -pthread -c $COMM/smtl.cpp -o $BUILD_DIR/smtl.o
+
+# gen benchmark macro according to cpuid feature
+gcc $SRC/cpuid.c -o $BUILD_DIR/cpuid
+SIMD_MACRO=" "
+SIMD_OBJ=" "
+for SIMD in `$BUILD_DIR/cpuid`;
+do
+    SIMD_MACRO="$SIMD_MACRO-D$SIMD "
+    SIMD_OBJ="$SIMD_OBJ$BUILD_DIR/$SIMD.o "
+    as -march=rv64gcv_zfh -c $ASM/$SIMD.S -o $BUILD_DIR/$SIMD.o
+done
+
+# compile cpufp
+g++ -O3 -march=rv64gcv_zfh -I$COMM $SIMD_MACRO -c $SRC/cpufp.cpp -o $BUILD_DIR/cpufp.o
+g++ -O3 -z noexecstack -pthread -o cpufp $BUILD_DIR/cpufp.o $BUILD_DIR/smtl.o $BUILD_DIR/table.o $SIMD_OBJ

--- a/riscv64/asm/_TME_.S
+++ b/riscv64/asm/_TME_.S
@@ -1,0 +1,195 @@
+.align 4
+
+.macro preserve_caller_vec
+    csrr t0, vtype
+    csrr t1, vl
+    vsetvli t2, x0, e8, m8
+    sub sp, sp, t2
+    vse8.v v0, (sp)
+    sub sp, sp, t2
+    vse8.v v8, (sp)
+    sub sp, sp, t2
+    vse8.v v16, (sp)
+    sub sp, sp, t2
+    vse8.v v24, (sp)
+.endm
+
+.macro restore_caller_vec
+    vsetvli t2, x0, e8, m8
+    vle8.v v24, (sp)
+    add sp, sp, t2
+    vle8.v v16, (sp)
+    add sp, sp, t2
+    vle8.v v8, (sp)
+    add sp, sp, t2
+    vle8.v v0, (sp)
+    add sp, sp, t2
+.endm
+
+#ifdef __APPLE__
+.globl _tme_vmadot_s32s8s8
+_tme_vmadot_s32s8s8:
+#else
+.globl tme_vmadot_s32s8s8
+tme_vmadot_s32s8s8:
+#endif
+    preserve_caller_vec
+    vsetvli t2, x0, e8, m8
+    vxor.vv v0, v0, v0
+    vxor.vv v8, v8, v8
+    vxor.vv v16, v16, v16
+    vxor.vv v24, v24, v24
+.tme.vmadot.s32s8s8.L1:
+    vsetvli t2, x0, e8, m1
+    vmadot v4, v0, v1
+    vmadot v6, v0, v1
+    vmadot v8, v0, v1
+    vmadot v10, v0, v1
+    vmadot v12, v0, v1
+    vmadot v14, v0, v1
+    vmadot v16, v0, v1
+    addi a0, a0, -1
+    vmadot v18, v0, v1
+    vmadot v20, v0, v1
+    vmadot v22, v0, v1
+    vmadot v24, v0, v1
+    vmadot v26, v0, v1
+    vmadot v28, v0, v1
+    vmadot v30, v0, v1
+    bnez a0, .tme.vmadot.s32s8s8.L1
+    restore_caller_vec
+    ret
+
+#ifdef __APPLE__
+.globl _tme_vmadotu_u32u8u8
+_tme_vmadotu_u32u8u8:
+#else
+.globl tme_vmadotu_u32u8u8
+tme_vmadotu_u32u8u8:
+#endif
+    preserve_caller_vec
+    vsetvli t2, x0, e8, m8
+    vxor.vv v0, v0, v0
+    vxor.vv v8, v8, v8
+    vxor.vv v16, v16, v16
+    vxor.vv v24, v24, v24
+.tme.vmadotu.u32u8u8.L1:
+    vsetvli t2, x0, e8, m1
+    vmadotu v4, v0, v1
+    vmadotu v6, v0, v1
+    vmadotu v8, v0, v1
+    vmadotu v10, v0, v1
+    vmadotu v12, v0, v1
+    vmadotu v14, v0, v1
+    vmadotu v16, v0, v1
+    addi a0, a0, -1
+    vmadotu v18, v0, v1
+    vmadotu v20, v0, v1
+    vmadotu v22, v0, v1
+    vmadotu v24, v0, v1
+    vmadotu v26, v0, v1
+    vmadotu v28, v0, v1
+    vmadotu v30, v0, v1
+    bnez a0, .tme.vmadotu.u32u8u8.L1
+    restore_caller_vec
+    ret
+
+#ifdef __APPLE__
+.globl _tme_vmadotus_s32u8s8
+_tme_vmadotus_s32u8s8:
+#else
+.globl tme_vmadotus_s32u8s8
+tme_vmadotus_s32u8s8:
+#endif
+    preserve_caller_vec
+    vsetvli t2, x0, e8, m8
+    vxor.vv v0, v0, v0
+    vxor.vv v8, v8, v8
+    vxor.vv v16, v16, v16
+    vxor.vv v24, v24, v24
+.tme.vmadotus.s32u8s8.L1:
+    vsetvli t2, x0, e8, m1
+    vmadotus v4, v0, v1
+    vmadotus v6, v0, v1
+    vmadotus v8, v0, v1
+    vmadotus v10, v0, v1
+    vmadotus v12, v0, v1
+    vmadotus v14, v0, v1
+    vmadotus v16, v0, v1
+    addi a0, a0, -1
+    vmadotus v18, v0, v1
+    vmadotus v20, v0, v1
+    vmadotus v22, v0, v1
+    vmadotus v24, v0, v1
+    vmadotus v26, v0, v1
+    vmadotus v28, v0, v1
+    vmadotus v30, v0, v1
+    bnez a0, .tme.vmadotus.s32u8s8.L1
+    restore_caller_vec
+    ret
+
+#ifdef __APPLE__
+.globl _tme_vmadotsu_s32s8u8
+_tme_vmadotsu_s32s8u8:
+#else
+.globl tme_vmadotsu_s32s8u8
+tme_vmadotsu_s32s8u8:
+#endif
+    preserve_caller_vec
+    vsetvli t2, x0, e8, m8
+    vxor.vv v0, v0, v0
+    vxor.vv v8, v8, v8
+    vxor.vv v16, v16, v16
+    vxor.vv v24, v24, v24
+.tme.vmadotsu.s32s8u8.L1:
+    vsetvli t2, x0, e8, m1
+    vmadotsu v4, v0, v1
+    vmadotsu v6, v0, v1
+    vmadotsu v8, v0, v1
+    vmadotsu v10, v0, v1
+    vmadotsu v12, v0, v1
+    vmadotsu v14, v0, v1
+    vmadotsu v16, v0, v1
+    addi a0, a0, -1
+    vmadotsu v18, v0, v1
+    vmadotsu v20, v0, v1
+    vmadotsu v22, v0, v1
+    vmadotsu v24, v0, v1
+    vmadotsu v26, v0, v1
+    vmadotsu v28, v0, v1
+    vmadotsu v30, v0, v1
+    bnez a0, .tme.vmadotsu.s32s8u8.L1
+    restore_caller_vec
+    ret
+
+#ifdef __APPLE__
+.globl _tme_vmadotslide_s32s8s8
+_tme_vmadotslide_s32s8s8:
+#else
+.globl tme_vmadotslide_s32s8s8
+tme_vmadotslide_s32s8s8:
+#endif
+    preserve_caller_vec
+    vsetvli t2, x0, e8, m8
+    vxor.vv v0, v0, v0
+    vxor.vv v8, v8, v8
+    vxor.vv v16, v16, v16
+    vxor.vv v24, v24, v24
+.tme.vmadotslide.s32s8s8.L1:
+    vsetvli t2, x0, e8, m1
+    vmadot v4, v0, v2
+    vmadot1 v6, v0, v2
+    vmadot2 v8, v0, v2
+    vmadot3 v10, v0, v2
+    vmadot v12, v0, v2
+    vmadot1 v14, v0, v2
+    vmadot2 v16, v0, v2
+    vmadot3 v18, v0, v2
+    addi a0, a0, -1
+    vmadot v20, v0, v2
+    vmadot1 v22, v0, v2
+    vmadot2 v24, v0, v2
+    vmadot3 v26, v0, v2
+    bnez a0, .tme.vmadotslide.s32s8s8.L1
+    restore_caller_vec
+    ret

--- a/riscv64/asm/_VECTOR_.S
+++ b/riscv64/asm/_VECTOR_.S
@@ -1,0 +1,288 @@
+.align 4
+
+.macro preserve_caller_vec
+    csrr t0, vtype
+    csrr t1, vl
+    vsetvli t2, x0, e8, m8
+    sub sp, sp, t2
+    vse8.v v0, (sp)
+    sub sp, sp, t2
+    vse8.v v8, (sp)
+    sub sp, sp, t2
+    vse8.v v16, (sp)
+    sub sp, sp, t2
+    vse8.v v24, (sp)
+.endm
+
+.macro restore_caller_vec
+    vsetvli t2, x0, e8, m8
+    vle8.v v24, (sp)
+    add sp, sp, t2
+    vle8.v v16, (sp)
+    add sp, sp, t2
+    vle8.v v8, (sp)
+    add sp, sp, t2
+    vle8.v v0, (sp)
+    add sp, sp, t2
+.endm
+
+#ifdef __APPLE__
+.globl _vector_vfmacc_vf_f16f16f16
+_vector_vfmacc_vf_f16f16f16:
+#else
+.globl vector_vfmacc_vf_f16f16f16
+vector_vfmacc_vf_f16f16f16:
+#endif
+    preserve_caller_vec
+    vsetvli t2, x0, e8, m8
+    vxor.vv v0, v0, v0
+    vxor.vv v8, v8, v8
+    vxor.vv v16, v16, v16
+    vxor.vv v24, v24, v24
+.vector.vfmacc.vf.f16f16f16.L1:
+    vsetvli t2, x0, e16, m1
+    vfmacc.vf v9, f0, v1
+    vfmacc.vf v10, f0, v1
+    vfmacc.vf v11, f0, v1
+    vfmacc.vf v12, f0, v1
+    vfmacc.vf v13, f0, v1
+    vfmacc.vf v14, f0, v1
+    vfmacc.vf v15, f0, v1
+    vfmacc.vf v16, f0, v1
+    vfmacc.vf v17, f0, v1
+    vfmacc.vf v18, f0, v1
+    vfmacc.vf v19, f0, v1
+    addi a0, a0, -1
+    vfmacc.vf v20, f0, v1
+    vfmacc.vf v21, f0, v1
+    vfmacc.vf v22, f0, v1
+    vfmacc.vf v23, f0, v1
+    vfmacc.vf v24, f0, v1
+    vfmacc.vf v25, f0, v1
+    vfmacc.vf v26, f0, v1
+    vfmacc.vf v27, f0, v1
+    vfmacc.vf v28, f0, v1
+    vfmacc.vf v29, f0, v1
+    vfmacc.vf v30, f0, v1
+    vfmacc.vf v31, f0, v1
+    bnez a0, .vector.vfmacc.vf.f16f16f16.L1
+    restore_caller_vec
+    ret
+
+#ifdef __APPLE__
+.globl _vector_vfmacc_vv_f16f16f16
+_vector_vfmacc_vv_f16f16f16:
+#else
+.globl vector_vfmacc_vv_f16f16f16
+vector_vfmacc_vv_f16f16f16:
+#endif
+    preserve_caller_vec
+    vsetvli t2, x0, e8, m8
+    vxor.vv v0, v0, v0
+    vxor.vv v8, v8, v8
+    vxor.vv v16, v16, v16
+    vxor.vv v24, v24, v24
+.vector.vfmacc.vv.f16f16f16.L1:
+    vsetvli t2, x0, e16, m1
+    vfmacc.vv v8, v0, v1
+    vfmacc.vv v9, v0, v1
+    vfmacc.vv v10, v0, v1
+    vfmacc.vv v11, v0, v1
+    vfmacc.vv v12, v0, v1
+    vfmacc.vv v13, v0, v1
+    vfmacc.vv v14, v0, v1
+    vfmacc.vv v15, v0, v1
+    vfmacc.vv v16, v0, v1
+    vfmacc.vv v17, v0, v1
+    vfmacc.vv v18, v0, v1
+    vfmacc.vv v19, v0, v1
+    addi a0, a0, -1
+    vfmacc.vv v20, v0, v1
+    vfmacc.vv v21, v0, v1
+    vfmacc.vv v22, v0, v1
+    vfmacc.vv v23, v0, v1
+    vfmacc.vv v24, v0, v1
+    vfmacc.vv v25, v0, v1
+    vfmacc.vv v26, v0, v1
+    vfmacc.vv v27, v0, v1
+    vfmacc.vv v28, v0, v1
+    vfmacc.vv v29, v0, v1
+    vfmacc.vv v30, v0, v1
+    vfmacc.vv v31, v0, v1
+    bnez a0, .vector.vfmacc.vv.f16f16f16.L1
+    restore_caller_vec
+    ret
+
+#ifdef __APPLE__
+.globl _vector_vfmacc_vf_f32f32f32
+_vector_vfmacc_vf_f32f32f32:
+#else
+.globl vector_vfmacc_vf_f32f32f32
+vector_vfmacc_vf_f32f32f32:
+#endif
+    preserve_caller_vec
+    vsetvli t2, x0, e8, m8
+    vxor.vv v0, v0, v0
+    vxor.vv v8, v8, v8
+    vxor.vv v16, v16, v16
+    vxor.vv v24, v24, v24
+.vector.vfmacc.vf.f32f32f32.L1:
+    vsetvli t2, x0, e32, m1
+    vfmacc.vf v9, f0, v1
+    vfmacc.vf v10, f0, v1
+    vfmacc.vf v11, f0, v1
+    vfmacc.vf v12, f0, v1
+    vfmacc.vf v13, f0, v1
+    vfmacc.vf v14, f0, v1
+    vfmacc.vf v15, f0, v1
+    vfmacc.vf v16, f0, v1
+    vfmacc.vf v17, f0, v1
+    vfmacc.vf v18, f0, v1
+    vfmacc.vf v19, f0, v1
+    addi a0, a0, -1
+    vfmacc.vf v20, f0, v1
+    vfmacc.vf v21, f0, v1
+    vfmacc.vf v22, f0, v1
+    vfmacc.vf v23, f0, v1
+    vfmacc.vf v24, f0, v1
+    vfmacc.vf v25, f0, v1
+    vfmacc.vf v26, f0, v1
+    vfmacc.vf v27, f0, v1
+    vfmacc.vf v28, f0, v1
+    vfmacc.vf v29, f0, v1
+    vfmacc.vf v30, f0, v1
+    vfmacc.vf v31, f0, v1
+    bnez a0, .vector.vfmacc.vf.f32f32f32.L1
+    restore_caller_vec
+    ret
+
+#ifdef __APPLE__
+.globl _vector_vfmacc_vv_f32f32f32
+_vector_vfmacc_vv_f32f32f32:
+#else
+.globl vector_vfmacc_vv_f32f32f32
+vector_vfmacc_vv_f32f32f32:
+#endif
+    preserve_caller_vec
+    vsetvli t2, x0, e8, m8
+    vxor.vv v0, v0, v0
+    vxor.vv v8, v8, v8
+    vxor.vv v16, v16, v16
+    vxor.vv v24, v24, v24
+.vector.vfmacc.vv.f32f32f32.L1:
+    vsetvli t2, x0, e32, m1
+    vfmacc.vv v8, v0, v1
+    vfmacc.vv v9, v0, v1
+    vfmacc.vv v10, v0, v1
+    vfmacc.vv v11, v0, v1
+    vfmacc.vv v12, v0, v1
+    vfmacc.vv v13, v0, v1
+    vfmacc.vv v14, v0, v1
+    vfmacc.vv v15, v0, v1
+    vfmacc.vv v16, v0, v1
+    vfmacc.vv v17, v0, v1
+    vfmacc.vv v18, v0, v1
+    vfmacc.vv v19, v0, v1
+    addi a0, a0, -1
+    vfmacc.vv v20, v0, v1
+    vfmacc.vv v21, v0, v1
+    vfmacc.vv v22, v0, v1
+    vfmacc.vv v23, v0, v1
+    vfmacc.vv v24, v0, v1
+    vfmacc.vv v25, v0, v1
+    vfmacc.vv v26, v0, v1
+    vfmacc.vv v27, v0, v1
+    vfmacc.vv v28, v0, v1
+    vfmacc.vv v29, v0, v1
+    vfmacc.vv v30, v0, v1
+    vfmacc.vv v31, v0, v1
+    bnez a0, .vector.vfmacc.vv.f32f32f32.L1
+    restore_caller_vec
+    ret
+
+#ifdef __APPLE__
+.globl _vector_vfmacc_vf_f64f64f64
+_vector_vfmacc_vf_f64f64f64:
+#else
+.globl vector_vfmacc_vf_f64f64f64
+vector_vfmacc_vf_f64f64f64:
+#endif
+    preserve_caller_vec
+    vsetvli t2, x0, e8, m8
+    vxor.vv v0, v0, v0
+    vxor.vv v8, v8, v8
+    vxor.vv v16, v16, v16
+    vxor.vv v24, v24, v24
+.vector.vfmacc.vf.f64f64f64.L1:
+    vsetvli t2, x0, e64, m1
+    vfmacc.vf v9, f0, v1
+    vfmacc.vf v10, f0, v1
+    vfmacc.vf v11, f0, v1
+    vfmacc.vf v12, f0, v1
+    vfmacc.vf v13, f0, v1
+    vfmacc.vf v14, f0, v1
+    vfmacc.vf v15, f0, v1
+    vfmacc.vf v16, f0, v1
+    vfmacc.vf v17, f0, v1
+    vfmacc.vf v18, f0, v1
+    vfmacc.vf v19, f0, v1
+    addi a0, a0, -1
+    vfmacc.vf v20, f0, v1
+    vfmacc.vf v21, f0, v1
+    vfmacc.vf v22, f0, v1
+    vfmacc.vf v23, f0, v1
+    vfmacc.vf v24, f0, v1
+    vfmacc.vf v25, f0, v1
+    vfmacc.vf v26, f0, v1
+    vfmacc.vf v27, f0, v1
+    vfmacc.vf v28, f0, v1
+    vfmacc.vf v29, f0, v1
+    vfmacc.vf v30, f0, v1
+    vfmacc.vf v31, f0, v1
+    bnez a0, .vector.vfmacc.vf.f64f64f64.L1
+    restore_caller_vec
+    ret
+
+#ifdef __APPLE__
+.globl _vector_vfmacc_vv_f64f64f64
+_vector_vfmacc_vv_f64f64f64:
+#else
+.globl vector_vfmacc_vv_f64f64f64
+vector_vfmacc_vv_f64f64f64:
+#endif
+    preserve_caller_vec
+    vsetvli t2, x0, e8, m8
+    vxor.vv v0, v0, v0
+    vxor.vv v8, v8, v8
+    vxor.vv v16, v16, v16
+    vxor.vv v24, v24, v24
+.vector.vfmacc.vv.f64f64f64.L1:
+    vsetvli t2, x0, e64, m1
+    vfmacc.vv v8, v0, v1
+    vfmacc.vv v9, v0, v1
+    vfmacc.vv v10, v0, v1
+    vfmacc.vv v11, v0, v1
+    vfmacc.vv v12, v0, v1
+    vfmacc.vv v13, v0, v1
+    vfmacc.vv v14, v0, v1
+    vfmacc.vv v15, v0, v1
+    vfmacc.vv v16, v0, v1
+    vfmacc.vv v17, v0, v1
+    vfmacc.vv v18, v0, v1
+    vfmacc.vv v19, v0, v1
+    addi a0, a0, -1
+    vfmacc.vv v20, v0, v1
+    vfmacc.vv v21, v0, v1
+    vfmacc.vv v22, v0, v1
+    vfmacc.vv v23, v0, v1
+    vfmacc.vv v24, v0, v1
+    vfmacc.vv v25, v0, v1
+    vfmacc.vv v26, v0, v1
+    vfmacc.vv v27, v0, v1
+    vfmacc.vv v28, v0, v1
+    vfmacc.vv v29, v0, v1
+    vfmacc.vv v30, v0, v1
+    vfmacc.vv v31, v0, v1
+    bnez a0, .vector.vfmacc.vv.f64f64f64.L1
+    restore_caller_vec
+    ret

--- a/riscv64/cpufp.cpp
+++ b/riscv64/cpufp.cpp
@@ -1,0 +1,331 @@
+#include "table.hpp"
+#include "smtl.hpp"
+
+#include <unistd.h>
+#include <cstdint>
+#include <ctime>
+#include <cstring>
+#include <cstdint>
+#include <vector>
+#include <sstream>
+#include <iomanip>
+
+using namespace std;
+
+extern "C"
+{
+#ifdef _TME_
+    void tme_vmadot_s32s8s8(int64_t);
+    void tme_vmadotu_u32u8u8(int64_t);
+    void tme_vmadotus_s32u8s8(int64_t);
+    void tme_vmadotsu_s32s8u8(int64_t);
+    void tme_vmadotslide_s32s8s8(int64_t);
+#endif
+
+#ifdef _VECTOR_
+    void vector_vfmacc_vf_f16f16f16(int64_t);
+    void vector_vfmacc_vv_f16f16f16(int64_t);
+    void vector_vfmacc_vf_f32f32f32(int64_t);
+    void vector_vfmacc_vv_f32f32f32(int64_t);
+    void vector_vfmacc_vf_f64f64f64(int64_t);
+    void vector_vfmacc_vv_f64f64f64(int64_t);
+#endif
+}
+
+typedef struct
+{
+    std::string isa;
+    std::string type;
+    std::string dim;
+    int64_t loop_time;
+    int64_t comp_pl;
+    void (*bench)(int64_t);
+} cpubm_t;
+static vector<cpubm_t> bm_list;
+
+static double get_time(struct timespec *start,
+    struct timespec *end)
+{
+    return end->tv_sec - start->tv_sec +
+        (end->tv_nsec - start->tv_nsec) * 1e-9;
+}
+
+static void reg_new_isa(std::string isa,
+    std::string type,
+    std::string dim,
+    int64_t loop_time,
+    int64_t comp_pl,
+    void (*bench)(int64_t))
+{
+    cpubm_t new_one;
+    new_one.isa = isa;
+    new_one.type = type;
+    new_one.dim = dim;
+    new_one.loop_time = loop_time;
+    new_one.comp_pl = comp_pl;
+    new_one.bench = bench;
+
+    bm_list.push_back(new_one);
+}
+
+static void thread_func(void *params)
+{
+    cpubm_t *bm = (cpubm_t*)params;
+    bm->bench(bm->loop_time);
+}
+
+static void cpubm_riscv64_one(smtl_handle sh,
+    cpubm_t &item,
+    Table &table)
+{
+    struct timespec start, end;
+    double time_used, perf;
+    char perfUnit = 'G';
+
+    int i;
+    int num_threads = smtl_num_threads(sh);
+
+    // warm up
+    for (i = 0; i < num_threads; i++)
+    {
+        smtl_add_task(sh, thread_func, (void*)&item);
+    }
+    smtl_begin_tasks(sh);
+    smtl_wait_tasks_finished(sh);
+
+    clock_gettime(CLOCK_MONOTONIC_RAW, &start);
+    for (i = 0; i < num_threads; i++)
+    {
+        smtl_add_task(sh, thread_func, (void*)&item);
+    }
+    smtl_begin_tasks(sh);
+    smtl_wait_tasks_finished(sh);
+    clock_gettime(CLOCK_MONOTONIC_RAW, &end);
+
+    time_used = get_time(&start, &end);
+    perf = item.loop_time * item.comp_pl * num_threads /
+        time_used;
+    if (perf > 1e12)
+    {
+        perfUnit = 'T';
+        perf /= 1e12;
+    }
+    else
+    {
+        perf /= 1e9;
+    }
+
+    stringstream ss;
+    ss << std::setprecision(5) << perf << " " << perfUnit << item.dim;
+
+    vector<string> cont;
+    cont.resize(3);
+    cont[0] = item.isa;
+    cont[1] = item.type;
+    cont[2] = ss.str();
+    table.addOneItem(cont);
+}
+
+static void cpubm_do_bench(std::vector<int> &set_of_threads,
+    uint32_t idle_time)
+{
+    int i;
+
+    if (bm_list.size() > 0)
+    {
+        int num_threads = set_of_threads.size();
+
+        printf("Number Threads: %d\n", num_threads);
+        printf("Thread Pool Binding:");
+        for (i = 0; i < num_threads; i++)
+        {
+            printf(" %d", set_of_threads[i]);
+        }
+        printf("\n");
+
+        // set table head
+        vector<string> ti;
+        ti.resize(3);
+        ti[0] = "Instruction Set";
+        ti[1] = "Core Computation";
+        ti[2] = "Peak Performance";
+
+        Table table;
+        table.setColumnNum(3);
+        table.addOneItem(ti);
+
+        // set thread pool
+        smtl_handle sh;
+        smtl_init(&sh, set_of_threads);
+
+        // traverse task list
+        cpubm_riscv64_one(sh, bm_list[0], table);
+        for (i = 1; i < bm_list.size(); i++)
+        {
+            sleep(idle_time);
+            cpubm_riscv64_one(sh, bm_list[i], table);
+        }
+
+        table.print();
+
+        smtl_fini(sh);
+    }
+    else
+    {
+        printf("Sorry, there's no any supported SIMD isa.\n");
+    }
+}
+
+static void parse_thread_pool(char *sets,
+    vector<int> &set_of_threads)
+{
+    if (sets[0] != '[')
+    {
+        return;
+    }
+    int pos = 1;
+    int left = 0, right = 0;
+    int state = 0;
+    while (sets[pos] != ']' && sets[pos] != '\0')
+    {
+        if (state == 0)
+        {
+            if (sets[pos] >= '0' && sets[pos] <= '9')
+            {
+                left *= 10;
+                left += (int)(sets[pos] - '0');
+            }
+            else if (sets[pos] == ',')
+            {
+                set_of_threads.push_back(left);
+                left = 0;
+            }
+            else if (sets[pos] == '-')
+            {
+                right = 0;
+                state = 1;
+            }
+        }
+        else if (state == 1)
+        {
+            if (sets[pos] >= '0' && sets[pos] <= '9')
+            {
+                right *= 10;
+                right += (int)(sets[pos] - '0');
+            }
+            else if (sets[pos] == ',')
+            {
+                int i;
+                for (i = left; i <= right; i++)
+                {
+                    set_of_threads.push_back(i);
+                }
+                left = 0;
+                state = 0;
+            }
+        }
+        pos++;
+    }
+    if (sets[pos] != ']')
+    {
+        return;
+    }
+    if (state == 0)
+    {
+        set_of_threads.push_back(left);
+    }
+    else if (state == 1)
+    {
+        int i;
+        for (i = left; i <= right; i++)
+        {
+            set_of_threads.push_back(i);
+        }
+    }
+}
+
+static void cpufp_register_isa()
+{
+#ifdef _TME_
+    reg_new_isa("tme", "vmadot(s32,s8,s8)", "OPS",
+        0x10000000LL, 3584LL, tme_vmadot_s32s8s8);
+    reg_new_isa("tme", "vmadotu(u32,u8,u8)", "OPS",
+        0x10000000LL, 3584LL, tme_vmadotu_u32u8u8);
+    reg_new_isa("tme", "vmadotus(s32,u8,s8)", "OPS",
+        0x10000000LL, 3584LL, tme_vmadotus_s32u8s8);
+    reg_new_isa("tme", "vmadotsu(s32,s8,u8)", "OPS",
+        0x10000000LL, 3584LL, tme_vmadotsu_s32s8u8);
+    reg_new_isa("tme", "vmadotslide(s32,s8,s8)", "OPS",
+        0x10000000LL, 3072LL, tme_vmadotslide_s32s8s8);
+#endif
+
+#ifdef _VECTOR_
+    size_t avl = 0;
+    __asm__ volatile("vsetvli %[avl], x0, e16, m1\n\t"
+                    : [avl] "=r" (avl)
+                    :
+                    : "cc");
+    reg_new_isa("vector", "vfmacc.vf(f16,f16,f16)", "FLOPS",
+        0x10000000LL, 48LL * avl, vector_vfmacc_vf_f16f16f16);
+    reg_new_isa("vector", "vfmacc.vv(f16,f16,f16)", "FLOPS",
+        0x10000000LL, 48LL * avl, vector_vfmacc_vv_f16f16f16);
+
+    __asm__ volatile("vsetvli %[avl], x0, e32, m1\n\t"
+                    : [avl] "=r" (avl)
+                    :
+                    : "cc");
+    reg_new_isa("vector", "vfmacc.vf(f32,f32,f32)", "FLOPS",
+        0x10000000LL, 48LL * avl, vector_vfmacc_vf_f32f32f32);
+    reg_new_isa("vector", "vfmacc.vv(f32,f32,f32)", "FLOPS",
+        0x10000000LL, 48LL * avl, vector_vfmacc_vv_f32f32f32);
+
+    __asm__ volatile("vsetvli %[avl], x0, e64, m1\n\t"
+                    : [avl] "=r" (avl)
+                    :
+                    : "cc");
+    reg_new_isa("vector", "vfmacc.vf(f64,f64,f64)", "FLOPS",
+        0x10000000LL, 48LL * avl, vector_vfmacc_vf_f64f64f64);
+    reg_new_isa("vector", "vfmacc.vv(f64,f64,f64)", "FLOPS",
+        0x10000000LL, 48LL * avl, vector_vfmacc_vv_f64f64f64);
+#endif
+}
+
+int main(int argc, char *argv[])
+{
+    vector<int> set_of_threads;
+    uint32_t idle_time = 0;
+
+    bool params_enough = false;
+
+    int i;
+    for (i = 1; i < argc; i++)
+    {
+        if (strncmp(argv[i], "--thread_pool=", 14) == 0)
+        {
+            parse_thread_pool(argv[i] + 14, set_of_threads);
+            params_enough = true;
+        }
+        else if (strncmp(argv[i], "--idle_time=", 12) == 0)
+        {
+            idle_time = (uint32_t)atoi(argv[i] + 12);
+        }
+    }
+    if (!params_enough)
+    {
+        fprintf(stderr, "Error: You must set --thread_pool parameter.\n");
+        fprintf(stderr, "You may also set --idle_time parameter.\n");
+        fprintf(stderr, "Usage: %s --thread_pool=[xxx] --idle_time=yyy\n", argv[0]);
+        fprintf(stderr, "[xxx] indicates all cores to benchmark.\n");
+        fprintf(stderr, "Example: [0,3,5-8,13-15].\n");
+        fprintf(stderr, "idle_time is the interval time(s) between every two benchmarks.\n");
+        fprintf(stderr, "idle_time parameter can be ignored, the default value is 0s.\n");
+        fprintf(stderr, "Notice: there must NOT be any spaces.\n");
+        exit(0);
+    }
+
+    cpufp_register_isa();
+    cpubm_do_bench(set_of_threads, idle_time);
+
+    return 0;
+}
+

--- a/riscv64/cpuid.c
+++ b/riscv64/cpuid.c
@@ -1,0 +1,54 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <asm/hwcap.h>
+#include <sys/auxv.h>
+
+#define ISA_V_HWCAP (1 << ('v' - 'a'))
+
+int main()
+{
+    FILE *cpuinfo_file;
+    char line[1024];
+    char *token;
+    const char *delimiter = ":";
+    const char *search_key = "vendorid";
+    char *vendor_id = NULL;
+
+    cpuinfo_file = fopen("/proc/cpuinfo", "r");
+    if (cpuinfo_file == NULL) {
+        printf("Failed to open /proc/cpuinfo\n");
+        return 1;
+    }
+
+    while (fgets(line, sizeof(line), cpuinfo_file)) {
+        if ((token = strtok(line, delimiter)) != NULL) {
+            if (strstr(token, search_key) != NULL) {
+                token = strtok(NULL, delimiter);
+                vendor_id = token + strspn(token, " \t");
+                break;
+            }
+        }
+    }
+
+    fclose(cpuinfo_file);
+
+    if (vendor_id) {
+        if (strncmp(vendor_id, "0x710", 5) == 0) {
+            printf("_TME_\n");
+        }
+    }
+
+    uint64_t hwcaps = getauxval(AT_HWCAP);
+
+#ifdef ISA_V_HWCAP
+    if (hwcaps & ISA_V_HWCAP)
+    {
+        printf("_VECTOR_\n");
+    }
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
这个PR对RISCV64架构处理器进行了初步的支持
- 一个简单cpuid。关于riscv cpuid的相关讨论：[参考讨论材料](https://lpc.events/event/16/contributions/1168/attachments/1055/2075/The%20Odyssey%20of%20HWCAP%20on%20RISC-V%20platforms%20with%20Palmer's%20Porosal%20in%20Backups.pdf)一般流程是先获取vendorid再根据vendorid获取相关自定义拓展的配置情况。HWCAP可以获取标准RVV拓展的支持情况，至于bf16、p拓展等等目前标准长期支持做法暂不明确。
- 标准RVV（risc-v-vector-extension）1.0的半精度、单精度、双精度乘累加指令perf支持
- 进迭时空自定义8bit整形AI拓展指令perf支持

---

This PR provides initial support for RISCV64 architecture processors.

- A simple cpuid. Discussion about RISC-V cpuid can be found [here](https://lpc.events/event/16/contributions/1168/attachments/1055/2075/The%20Odyssey%20of%20HWCAP%20on%20RISC-V%20platforms%20with%20Palmer's%20Porosal%20in%20Backups.pdf). The general process is to first obtain the vendor ID and then obtain the configuration of relevant custom extensions based on the vendor ID. HWCAP can be used to obtain the support status of standard RVV extensions, while the support status of extensions such as bf16 and p is not currently clear in the standard long-term support practice.
- Performance benchmark support for standard RVV (RISC-V Vector Extension) 1.0 half precision, single precision, and double precision multiply-accumulate instructions.
- Performance benchmark support for custom 8-bit integer AI extensions of SpacemiT inc’s K1 chip.