### PR TITLE
Osx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It can automatically sense the local SIMD|DSA ISAs while compiling.
 
 | Arch          |Linux| MacOS| Windows|
 |:--------------|:---:|:----:|:------:|
-| arm64         | yes |  no  |   no   |
+| arm64         | yes |  yes |   no   |
 | e2k           | yes |  no  |   no   |
 | loongarch64   | yes |  no  |   no   |
 | riscv64       | yes |  no  |   no   |

--- a/arm64/cpuid.c
+++ b/arm64/cpuid.c
@@ -1,10 +1,18 @@
 #include <stdio.h>
 #include <stdint.h>
+#ifndef __APPLE__
 #include <asm/hwcap.h>
 #include <sys/auxv.h>
+#else
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <string.h>
+#endif
 
 int main()
 {
+#ifndef __APPLE__
     uint64_t hwcaps = getauxval(AT_HWCAP);
 
 #ifdef HWCAP2_I8MM
@@ -41,7 +49,35 @@ int main()
         printf("_ASIMD_\n");
     }
 #endif
+#else
+    size_t size = 4;
+    uint32_t res;
+
+    sysctlbyname("hw.optional.arm.FEAT_I8MM", &res, &size, NULL, 0);
+    if (res == 1) {
+        printf("_I8MM_\n");
+    }
+
+    sysctlbyname("hw.optional.arm.FEAT_BF16", &res, &size, NULL, 0);
+    if (res == 1) {
+        printf("_BF16_\n");
+    }
+
+    sysctlbyname("hw.optional.arm.FEAT_DotProd", &res, &size, NULL, 0);
+    if (res == 1) {
+        printf("_ASIMD_DP_\n");
+    }
+
+    sysctlbyname("hw.optional.AdvSIMD_HPFPCv", &res, &size, NULL, 0);
+    if (res == 1) {
+        printf("_ASIMD_HP_\n");
+    }
+
+    sysctlbyname("hw.optional.AdvSIMD", &res, &size, NULL, 0);
+    if (res == 1) {
+        printf("_ASIMD_\n");
+    }
+#endif
 
     return 0;
 }
-

--- a/benchmark_result/arm64.md
+++ b/benchmark_result/arm64.md
@@ -462,3 +462,139 @@ Thread Pool Binding: 0 1 2 3
 -------------------------------------------------------------
 </pre>
 
+## Apple M2 Max (Macbook Pro 16), macos 15.1
+
+Setting: 8xAvalanche P-Cores + 4xBlizzard E-Cores
+
+For 1 P-core:
+
+<pre>
+❯ ./cpufp --thread_pool=[0]
+Number Threads: 1
+Thread Pool Binding: 0
+Warning: cpu thread policy is not supported by OS
+----------------------------------------------------------------
+| Instruction Set | Core Computation        | Peak Performance |
+| i8mm            | mmla(s32,s8,s8)         | 347.22 GOPS      |
+| i8mm            | mmla(u32,u8,u8)         | 353.72 GOPS      |
+| i8mm            | mmla(s32,u8,s8)         | 361.84 GOPS      |
+| i8mm            | dp4a.vs(s32,s8,u8)      | 426.77 GOPS      |
+| i8mm            | dp4a.vs(s32,u8,s8)      | 418.49 GOPS      |
+| i8mm            | dp4a.vv(s32,u8,s8)      | 436.31 GOPS      |
+| asimd_dp        | dp4a.vs(s32,s8,s8)      | 425.79 GOPS      |
+| asimd_dp        | dp4a.vv(s32,s8,s8)      | 420.44 GOPS      |
+| asimd_dp        | dp4a.vs(u32,u8,u8)      | 430.16 GOPS      |
+| asimd_dp        | dp4a.vv(u32,u8,u8)      | 425.55 GOPS      |
+| bf16            | mmla(f32,bf16,bf16)     | 51.959 GFLOPS    |
+| bf16            | dp2a.vs(f32,bf16,bf16)  | 53.449 GFLOPS    |
+| bf16            | dp2a.vv(f32,bf16,bf16)  | 53.995 GFLOPS    |
+| asimd_hp        | fmla.vs(fp16,fp16,fp16) | 215.06 GFLOPS    |
+| asimd_hp        | fmla.vv(fp16,fp16,fp16) | 210.01 GFLOPS    |
+| asimd           | fmla.vs(f32,f32,f32)    | 105.54 GFLOPS    |
+| asimd           | fmla.vv(f32,f32,f32)    | 107.27 GFLOPS    |
+| asimd           | fmla.vs(f64,f64,f64)    | 54.109 GFLOPS    |
+| asimd           | fmla.vv(f64,f64,f64)    | 51.883 GFLOPS    |
+----------------------------------------------------------------
+</pre>
+
+For 8 P-cores:
+
+<pre>
+❯ ./cpufp --thread_pool=[0-7]
+Number Threads: 8
+Thread Pool Binding: 0 1 2 3 4 5 6 7
+Warning: cpu thread policy is not supported by OS
+Warning: cpu thread policy is not supported by OS
+Warning: cpu thread policy is not supported by OS
+Warning: cpu thread policy is not supported by OS
+Warning: cpu thread policy is not supported by OS
+Warning: cpu thread policy is not supported by OS
+Warning: cpu thread policy is not supported by OS
+Warning: cpu thread policy is not supported by OS
+----------------------------------------------------------------
+| Instruction Set | Core Computation        | Peak Performance |
+| i8mm            | mmla(s32,s8,s8)         | 2.5416 TOPS      |
+| i8mm            | mmla(u32,u8,u8)         | 2.2677 TOPS      |
+| i8mm            | mmla(s32,u8,s8)         | 2.6085 TOPS      |
+| i8mm            | dp4a.vs(s32,s8,u8)      | 3.0364 TOPS      |
+| i8mm            | dp4a.vs(s32,u8,s8)      | 3.0657 TOPS      |
+| i8mm            | dp4a.vv(s32,u8,s8)      | 3.1035 TOPS      |
+| asimd_dp        | dp4a.vs(s32,s8,s8)      | 2.9913 TOPS      |
+| asimd_dp        | dp4a.vv(s32,s8,s8)      | 3.0582 TOPS      |
+| asimd_dp        | dp4a.vs(u32,u8,u8)      | 2.9646 TOPS      |
+| asimd_dp        | dp4a.vv(u32,u8,u8)      | 2.3463 TOPS      |
+| bf16            | mmla(f32,bf16,bf16)     | 384.6 GFLOPS     |
+| bf16            | dp2a.vs(f32,bf16,bf16)  | 375.38 GFLOPS    |
+| bf16            | dp2a.vv(f32,bf16,bf16)  | 369.55 GFLOPS    |
+| asimd_hp        | fmla.vs(fp16,fp16,fp16) | 1.5043 TFLOPS    |
+| asimd_hp        | fmla.vv(fp16,fp16,fp16) | 1.5192 TFLOPS    |
+| asimd           | fmla.vs(f32,f32,f32)    | 763 GFLOPS       |
+| asimd           | fmla.vv(f32,f32,f32)    | 765.33 GFLOPS    |
+| asimd           | fmla.vs(f64,f64,f64)    | 377.3 GFLOPS     |
+| asimd           | fmla.vv(f64,f64,f64)    | 377.05 GFLOPS    |
+----------------------------------------------------------------
+</pre>
+
+For 1 E-core:
+<pre>
+❯ taskpolicy -c background ./cpufp --thread_pool=[0]
+Number Threads: 1
+Thread Pool Binding: 0
+Warning: cpu thread policy is not supported by OS
+----------------------------------------------------------------
+| Instruction Set | Core Computation        | Peak Performance |
+| i8mm            | mmla(s32,s8,s8)         | 101.41 GOPS      |
+| i8mm            | mmla(u32,u8,u8)         | 97.71 GOPS       |
+| i8mm            | mmla(s32,u8,s8)         | 100.49 GOPS      |
+| i8mm            | dp4a.vs(s32,s8,u8)      | 101.54 GOPS      |
+| i8mm            | dp4a.vs(s32,u8,s8)      | 96.847 GOPS      |
+| i8mm            | dp4a.vv(s32,u8,s8)      | 98.375 GOPS      |
+| asimd_dp        | dp4a.vs(s32,s8,s8)      | 102.21 GOPS      |
+| asimd_dp        | dp4a.vv(s32,s8,s8)      | 95.13 GOPS       |
+| asimd_dp        | dp4a.vs(u32,u8,u8)      | 98.558 GOPS      |
+| asimd_dp        | dp4a.vv(u32,u8,u8)      | 102.73 GOPS      |
+| bf16            | mmla(f32,bf16,bf16)     | 12.526 GFLOPS    |
+| bf16            | dp2a.vs(f32,bf16,bf16)  | 11.987 GFLOPS    |
+| bf16            | dp2a.vv(f32,bf16,bf16)  | 11.877 GFLOPS    |
+| asimd_hp        | fmla.vs(fp16,fp16,fp16) | 50.557 GFLOPS    |
+| asimd_hp        | fmla.vv(fp16,fp16,fp16) | 51.691 GFLOPS    |
+| asimd           | fmla.vs(f32,f32,f32)    | 23.584 GFLOPS    |
+| asimd           | fmla.vv(f32,f32,f32)    | 23.78 GFLOPS     |
+| asimd           | fmla.vs(f64,f64,f64)    | 12.689 GFLOPS    |
+| asimd           | fmla.vv(f64,f64,f64)    | 12.744 GFLOPS    |
+----------------------------------------------------------------
+</pre>
+
+For 4 E-cores (OS is running and therefore using some of them):
+<pre>
+❯ taskpolicy -c background ./cpufp --thread_pool=[0-4]
+Number Threads: 5
+Thread Pool Binding: 0 1 2 3 4
+Warning: cpu thread policy is not supported by OS
+Warning: cpu thread policy is not supported by OS
+Warning: cpu thread policy is not supported by OS
+Warning: cpu thread policy is not supported by OS
+Warning: cpu thread policy is not supported by OS
+----------------------------------------------------------------
+| Instruction Set | Core Computation        | Peak Performance |
+| i8mm            | mmla(s32,s8,s8)         | 257.56 GOPS      |
+| i8mm            | mmla(u32,u8,u8)         | 277.03 GOPS      |
+| i8mm            | mmla(s32,u8,s8)         | 260.58 GOPS      |
+| i8mm            | dp4a.vs(s32,s8,u8)      | 262.47 GOPS      |
+| i8mm            | dp4a.vs(s32,u8,s8)      | 253.67 GOPS      |
+| i8mm            | dp4a.vv(s32,u8,s8)      | 261.9 GOPS       |
+| asimd_dp        | dp4a.vs(s32,s8,s8)      | 254.58 GOPS      |
+| asimd_dp        | dp4a.vv(s32,s8,s8)      | 265.64 GOPS      |
+| asimd_dp        | dp4a.vs(u32,u8,u8)      | 243.53 GOPS      |
+| asimd_dp        | dp4a.vv(u32,u8,u8)      | 261.77 GOPS      |
+| bf16            | mmla(f32,bf16,bf16)     | 32.942 GFLOPS    |
+| bf16            | dp2a.vs(f32,bf16,bf16)  | 33.222 GFLOPS    |
+| bf16            | dp2a.vv(f32,bf16,bf16)  | 32.07 GFLOPS     |
+| asimd_hp        | fmla.vs(fp16,fp16,fp16) | 131.08 GFLOPS    |
+| asimd_hp        | fmla.vv(fp16,fp16,fp16) | 138.56 GFLOPS    |
+| asimd           | fmla.vs(f32,f32,f32)    | 58.652 GFLOPS    |
+| asimd           | fmla.vv(f32,f32,f32)    | 62.704 GFLOPS    |
+| asimd           | fmla.vs(f64,f64,f64)    | 32.681 GFLOPS    |
+| asimd           | fmla.vv(f64,f64,f64)    | 32.855 GFLOPS    |
+----------------------------------------------------------------
+</pre>

--- a/build_arm64.sh
+++ b/build_arm64.sh
@@ -2,6 +2,7 @@ SRC=arm64
 ASM=$SRC/asm
 COMM=common
 BUILD_DIR=build_dir
+OS=$(uname -o)
 
 # make directory
 if [ -d "$BUILD_DIR" ]; then
@@ -11,20 +12,28 @@ else
 fi
 
 # build common tools
-g++ -O3 -c $COMM/table.cpp -o $BUILD_DIR/table.o
-g++ -O3 -pthread -c $COMM/smtl.cpp -o $BUILD_DIR/smtl.o
+g++ -O3 -std=gnu++17 -c $COMM/table.cpp -o $BUILD_DIR/table.o
+g++ -O3 -std=gnu++17 -pthread -c $COMM/smtl.cpp -o $BUILD_DIR/smtl.o
 
 # gen benchmark macro according to cpuid feature
 gcc $SRC/cpuid.c -o $BUILD_DIR/cpuid
 SIMD_MACRO=" "
 SIMD_OBJ=" "
+AS_EXTRA_FLAGS="-mcpu=all"
+if [ "${OS}" == "Darwin" ]; then
+    AS_EXTRA_FLAGS="-mcpu=apple-m2"
+fi
 for SIMD in `$BUILD_DIR/cpuid`;
 do
     SIMD_MACRO="$SIMD_MACRO-D$SIMD "
     SIMD_OBJ="$SIMD_OBJ$BUILD_DIR/$SIMD.o "
-    as -mcpu=all -c $ASM/$SIMD.S -o $BUILD_DIR/$SIMD.o
+    as ${AS_EXTRA_FLAGS} -c $ASM/$SIMD.S -o $BUILD_DIR/$SIMD.o
 done
 
 # compile cpufp
-g++ -O3 -I$COMM $SIMD_MACRO -c $SRC/cpufp.cpp -o $BUILD_DIR/cpufp.o
-g++ -O3 -z noexecstack -pthread -o cpufp $BUILD_DIR/cpufp.o $BUILD_DIR/smtl.o $BUILD_DIR/table.o $SIMD_OBJ
+EXTRA_CFLAGS=""
+if [ "${OS}" != "Darwin" ]; then
+    EXTRA_CFLAGS="-z noexecstack"
+fi
+g++ -std=gnu++17 -O3 -I$COMM $SIMD_MACRO -c $SRC/cpufp.cpp -o $BUILD_DIR/cpufp.o
+g++ -std=gnu++17 -O3 ${EXTRA_CFLAGS} -pthread -o cpufp $BUILD_DIR/cpufp.o $BUILD_DIR/smtl.o $BUILD_DIR/table.o $SIMD_OBJ

--- a/common/table.hpp
+++ b/common/table.hpp
@@ -20,7 +20,7 @@ public:
 private:
     int col;
     std::vector<int> colWidths;
-    std::vector<std::vector<std::string>> contents;
+    std::vector<std::vector<std::string> > contents;
 };
 
 #endif


### PR DESCRIPTION
Add support for macosx on apple silicon (I don't have access to x86 macbooks anymore, but it should be easy to add if some one would dump output of `sysctl -a` from x86 osx).

There is a caveat - right now there is no way to bind thread to CPU as while API is still there on Apple Silicon it always returns KERN_NOT_SUPPORTED. However osx scheduler is doing a good job to pin it to fastest available core most of the time.